### PR TITLE
Fix: align with Backend develop API changes

### DIFF
--- a/src/deltadefi/api.py
+++ b/src/deltadefi/api.py
@@ -61,6 +61,7 @@ class API:
             "DELETE": self.session.delete,
             "PUT": self.session.put,
             "POST": self.session.post,
+            "PATCH": self.session.patch,
         }.get(http_method, "GET")
 
     def _prepare_params(self, params):

--- a/src/deltadefi/models/models.py
+++ b/src/deltadefi/models/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypedDict
 
 OrderStatusType = Literal["openOrder", "orderHistory", "tradingHistory"]
 
@@ -21,6 +21,8 @@ OrderTypes = {
     "LimitOrder": "limit",
 }
 
+OrderExecutionRole = Literal["maker", "taker"]
+
 
 @dataclass
 class AssetRecord:
@@ -38,8 +40,56 @@ class TransactionStatus:
     confirmed = "confirmed"
 
 
+class OrderExecutionRecordResponse(TypedDict):
+    """Order execution record representing a single trade execution."""
+
+    id: str
+    order_id: str
+    account_id: str
+    execution_price: str
+    filled_base_qty: str
+    filled_quote_qty: str
+    commission_unit: str
+    commission: str
+    role: OrderExecutionRole
+    counter_party_order_id: str
+    created_at: str
+
+
+class OrderResponse(TypedDict):
+    """Order response with quantities in human-readable format."""
+
+    id: str
+    account_id: str
+    active_order_utxo_id: str | None
+    status: OrderStatus
+    symbol: str
+    base_qty: str
+    quote_qty: str
+    side: OrderSide
+    price: str
+    type: OrderType
+    slippage_bp: int | None
+    market_order_limit_price: str | None
+    locked_base_qty: str
+    locked_quote_qty: str
+    executed_base_qty: str
+    executed_quote_qty: str
+    ob_open_order_base_qty: str
+    commission_unit: str
+    commission: str
+    commission_rate_bp: int
+    executed_price: str
+    created_at: str
+    updated_at: str
+    order_execution_records: list[OrderExecutionRecordResponse] | None
+
+
+# Deprecated: Use OrderResponse instead
 @dataclass
 class OrderJSON:
+    """Deprecated: Use OrderResponse instead."""
+
     order_id: str
     status: OrderStatus
     symbol: str
@@ -77,8 +127,11 @@ class AssetBalance:
     locked: int
 
 
+# Deprecated: Use OrderExecutionRecordResponse instead
 @dataclass
 class OrderFillingRecordJSON:
+    """Deprecated: Use OrderExecutionRecordResponse instead."""
+
     execution_id: str
     order_id: str
     status: OrderStatus

--- a/src/deltadefi/responses/accounts.py
+++ b/src/deltadefi/responses/accounts.py
@@ -4,8 +4,10 @@ from typing import TypedDict
 from deltadefi.models.models import (
     AssetBalance,
     DepositRecord,
+    OrderExecutionRecordResponse,
     OrderFillingRecordJSON,
     OrderJSON,
+    OrderResponse,
     WithdrawalRecord,
 )
 
@@ -41,12 +43,14 @@ class GetWithdrawalRecordsResponse(list[WithdrawalRecord]):
     pass
 
 
+# Deprecated: Use get_open_orders, get_trade_orders, or get_trades instead
 @dataclass
 class OrderRecordsData(TypedDict):
     orders: list[OrderJSON]
     order_filling_records: list[OrderFillingRecordJSON]
 
 
+# Deprecated: Use get_open_orders, get_trade_orders, or get_trades instead
 @dataclass
 class GetOrderRecordsResponse(TypedDict):
     data: list[OrderRecordsData]
@@ -56,7 +60,7 @@ class GetOrderRecordsResponse(TypedDict):
 
 @dataclass
 class GetOrderRecordResponse(TypedDict):
-    order_json: OrderJSON
+    order: OrderResponse
 
 
 @dataclass
@@ -89,4 +93,94 @@ class GetAccountInfoResponse(TypedDict):
 
 @dataclass
 class GetAccountBalanceResponse(list[AssetBalance]):
+    pass
+
+
+# New response types for espresso develop branch
+
+
+@dataclass
+class BuildRequestTransferalTransactionResponse(TypedDict):
+    tx_hex: str
+
+
+@dataclass
+class SubmitRequestTransferalTransactionResponse(TypedDict):
+    tx_hash: str
+
+
+@dataclass
+class GetSpotAccountResponse(TypedDict):
+    account_id: str
+    account_type: str
+    encrypted_operation_key: str
+    operation_key_hash: str
+    created_at: str
+
+
+@dataclass
+class CreateSpotAccountResponse(TypedDict):
+    account_id: str
+    account_type: str
+    encrypted_operation_key: str
+    operation_key_hash: str
+    created_at: str
+
+
+@dataclass
+class UpdateSpotAccountResponse(TypedDict):
+    account_id: str
+    account_type: str
+    encrypted_operation_key: str
+    operation_key_hash: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class TransferalRecord(TypedDict):
+    id: str
+    account_id: str
+    to_address: str
+    status: str
+    transferal_type: str
+    assets: list[dict]
+    tx_hash: str | None
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class GetTransferalRecordsResponse(list[TransferalRecord]):
+    pass
+
+
+@dataclass
+class GetTransferalRecordResponse(TypedDict):
+    transferal: TransferalRecord
+
+
+@dataclass
+class GetAPIKeyResponse(TypedDict):
+    api_key: str
+    created_at: str
+
+
+@dataclass
+class GetMaxDepositResponse(TypedDict):
+    max_deposit: str
+
+
+@dataclass
+class GetOpenOrdersResponse(list[OrderResponse]):
+    pass
+
+
+@dataclass
+class GetTradeOrdersResponse(list[OrderResponse]):
+    pass
+
+
+@dataclass
+class GetTradesResponse(list[OrderExecutionRecordResponse]):
     pass

--- a/src/deltadefi/responses/responses.py
+++ b/src/deltadefi/responses/responses.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import TypedDict
 
-from deltadefi.models import OrderJSON
+from deltadefi.models import OrderResponse
 
 
 @dataclass
@@ -50,7 +50,7 @@ class BuildPlaceOrderTransactionResponse(TypedDict):
 
 @dataclass
 class SubmitPlaceOrderTransactionResponse(TypedDict):
-    order: OrderJSON
+    order: OrderResponse
 
 
 @dataclass
@@ -59,15 +59,11 @@ class PostOrderResponse(SubmitPlaceOrderTransactionResponse):
 
 
 @dataclass
-class BuildCancelOrderTransactionResponse(TypedDict):
-    tx_hex: str
+class CancelOrderResponse(TypedDict):
+    order_id: str
 
 
 @dataclass
-class BuildCancelAllOrdersTransactionResponse(TypedDict):
-    tx_hexes: list[str]
-
-
-@dataclass
-class SubmitCancelAllOrdersTransactionResponse(TypedDict):
-    cancelled_order_ids: list[str]
+class CancelAllOrdersResponse(TypedDict):
+    symbol: str
+    order_ids: list[str]


### PR DESCRIPTION
   Breaking changes:
   - Cancel order API changed from build/submit to direct POST endpoint
   - Order placement now uses base_quantity/quote_quantity instead of quantity

   New endpoints:
   - get_open_orders, get_trade_orders, get_trades for order retrieval
   - get_spot_account, create_spot_account, update_spot_account
   - build/submit_request_transferal_transaction
   - get_transferal_records, get_transferal_record_by_tx_hash
   - get_api_key, get_max_deposit

   Model updates:
   - Added OrderResponse TypedDict with new fields
   - Added OrderExecutionRecordResponse for trade records
   - Added CancelOrderResponse, CancelAllOrdersResponse

   Deprecations:
   - get_order_records() deprecated in favor of new endpoints
   - OrderJSON and OrderFillingRecordJSON marked as deprecated